### PR TITLE
Initiativen Paging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ public
 /.Python
 /include
 /lib
+venv

--- a/static/dib.css
+++ b/static/dib.css
@@ -916,6 +916,11 @@ header .alert {
   background-color: #31B0D5;
 }
 
+.paging {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
 /* Badge Color: Is Being Voted On */
 
 .badge-vote {

--- a/templates/fragments/initiative/list.html
+++ b/templates/fragments/initiative/list.html
@@ -7,6 +7,24 @@
 	</div>
 </div>
 {% endfor %}
+
+
+{% if page.has_other_pages %}
+<div class="paging">
+	{% if page.has_previous %}
+		<button onclick="load_page({{page.previous_page_number}});">Vorherige</button>
+	{% else %}
+		<button disabled>Vorherige</button>
+	{% endif %}
+
+	{% if page.has_next %}
+		<button onclick="load_page({{page.next_page_number}});">Nächste</button>
+	{% else %}
+		<button disabled>Nächste</button>
+	{% endif %}
+</div>
+{% endif %}
+
 <script>
 // Initialize Tooltips
 $(function () {

--- a/templates/initproc/blocks/filter.html
+++ b/templates/initproc/blocks/filter.html
@@ -1,4 +1,5 @@
 <form id="filters" data-ajax-submit="true" method="GET">
+	<input name="page" type="hidden" id="filters-page" value="1" />
 	<div class="typefilter">
 		<div class="container">
 			<div class="row no-gutters">
@@ -92,3 +93,13 @@
 		</div>
     </div>
  </form>
+{% if with_js %}
+<script type="text/javascript">
+  	$(function(){
+  		var submitTimeout = null;
+	    $('.typefilter input').change(function(item) {
+	    	load_page(1);
+	    });	
+  	});
+</script>
+{% endif %}

--- a/templates/initproc/index.html
+++ b/templates/initproc/index.html
@@ -52,11 +52,16 @@
 
 {{ block.super }}
 <script type="text/javascript">
+	function load_page(num) {
+	    	$("#init-list").html("Loading ...");
+	    	$("#filters-page").val(num);
+	    	$("#filters").submit();
+	};
+
   	$(function(){
   		var submitTimeout = null;
 	    $('.typefilter input').change(function(item) {
-	    	$("#init-list").html("Loading ...");
-	    	$("#filters").submit();
+	    	load_page(1);
 	    });	
   	});
   	// Initialize Tooltips


### PR DESCRIPTION
This PR adds Paging to the Initiatives-List-View. By default this shows 25 items and prev & next buttons on the bottom. It keeps the filter-setting when you switch pages and resets the page count when you change the filter.

Further more, this also ensures we are showing the right filter-setup after each load, fixing a long-standing bug of filter-view and actually shown initiatives running out of sync.

_Two remarks_:
 - This should speed up view time, especially coming to the page on first access
 - Without search (enabled in the UI) this means you can efficiently search on-page anymore either 

Looks like this:
![screenshot-20180912224430-1748x486](https://user-images.githubusercontent.com/40496/45452350-0a80ac80-b6de-11e8-83c1-fce302b93d7f.png)
![screenshot-20180912224438-1758x1337](https://user-images.githubusercontent.com/40496/45452356-0d7b9d00-b6de-11e8-9ebb-63ccc1e6449e.png)
