### PR TITLE
fix database initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ pip install -r requirements.txt
 
 3. (create and) update the database
 ```
+python manage.py migrate pinax_notifications
+python manage.py migrate initproc 0009
 python manage.py migrate
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ pip install -r requirements.txt
 
 3. (create and) update the database
 ```
-python manage.py migrate pinax_notifications
 python manage.py migrate initproc 0009
 python manage.py migrate
 ```

--- a/voty/initproc/migrations/0001_initial.py
+++ b/voty/initproc/migrations/0001_initial.py
@@ -13,6 +13,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('pinax_notifications', '0001_initial'),
     ]
 
     operations = [

--- a/voty/initproc/migrations/0025_teams_and_permissions.py
+++ b/voty/initproc/migrations/0025_teams_and_permissions.py
@@ -31,7 +31,7 @@ def init_teams_and_permissions(apps, schema_editor):
     if team:
         for user in User.objects.filter(is_staff=True, is_active=True):
             user.groups.add (team)
-            print ('... added all staff members to group "Prüfungsteam"')
+        print ('... added all staff members to group "Prüfungsteam"')
 
         permission = Permission.objects.get(content_type__app_label='initproc', codename='add_moderation')
         team.permissions.add (permission)


### PR DESCRIPTION
Fixes #218 

The problem is that `django.contrib.auth` only creates the default permissions for new models when it receives the `post_migrate` signal, which is sent only after an entire run of `manage.py migration`, not after each migration.

I couldn't figure out a way to cause the permissions to be created in between. Both `django.contrib.auth.management.createPermissions` and `models.signals.post_migrate.send` require an application configuration, and apparently during the migration process the application configurations are replaced by stubs that don't contain information about the models.

Instead, I've changed the instructions in the readme for the database initialization. This is now in three stages, since we need to migrate to `voty/initproc/migrations/0009_moderation.py` without immediately continuing to `voty/initproc/migrations/0025_teams_and_permissions.py`, but running `manage.py migrate initproc 0009` doesn't run the migrations for `pinax_notifications`, which are required in this post-migration step:

https://github.com/DemokratieInBewegung/plenum/blob/8e04f107dc9f8bc293293b0c02c85c51b8c5c84d/voty/initproc/apps.py#L64

so we have to run those first. All in all:

```
python manage.py migrate pinax_notifications
python manage.py migrate initproc 0009
python manage.py migrate
```

This is not an elegant solution, but I don't see how to do it in fewer steps.