### PR TITLE
replaced absolute avatar URLs by relative URLs

### DIFF
--- a/templates/fragments/avatar.html
+++ b/templates/fragments/avatar.html
@@ -1,6 +1,6 @@
-{% load avatar_full_url %}
+{% load avatar_relative_url %}
 <img
-	src="{% avatar_full_url user size %}"
+	src="{% avatar_relative_url user size %}"
 	title="{{user.firstname|default:user.username}}"
 	width="{{ size }}"
 	height="{{ size }}"

--- a/voty/initadmin/templatetags/avatar_full_url.py
+++ b/voty/initadmin/templatetags/avatar_full_url.py
@@ -9,11 +9,4 @@ register = template.Library()
 @cache_result()
 @register.simple_tag(takes_context=True)
 def avatar_full_url(context, user, size=settings.AVATAR_DEFAULT_SIZE):
-	url = avatar_url(user, size)
-	if url.startswith("http"):
-		return url
-	if getattr(context, "request", None):
-		return context.request.build_absolute_uri(url)
-	## YAK!!!
-	site = Site.objects.get_current()
-	return "http://" + site.domain + url
+	return avatar_url(user, size)

--- a/voty/initadmin/templatetags/avatar_relative_url.py
+++ b/voty/initadmin/templatetags/avatar_relative_url.py
@@ -8,5 +8,5 @@ register = template.Library()
 
 @cache_result()
 @register.simple_tag(takes_context=True)
-def avatar_full_url(context, user, size=settings.AVATAR_DEFAULT_SIZE):
+def avatar_relative_url(context, user, size=settings.AVATAR_DEFAULT_SIZE):
 	return avatar_url(user, size)

--- a/voty/initadmin/templatetags/avatar_relative_url.py
+++ b/voty/initadmin/templatetags/avatar_relative_url.py
@@ -1,5 +1,4 @@
 from avatar.templatetags.avatar_tags import avatar_url
-from django.contrib.sites.models import Site
 from avatar.utils import cache_result
 from django import template
 from django.conf import settings


### PR DESCRIPTION
This fixes #250 by using the relative URLs provided by the avatar package and removing our code that turned them into absolute URLs.

@gnunicorn What was the purpose of making them absolute? It seems to work well with the relative URLs.

#250 seems to occur because this line adds the `http://` scheme:

https://github.com/DemokratieInBewegung/plenum/blob/c9d3e56229070a6dd0abd7cd49503b6925a1834d/voty/initadmin/templatetags/avatar_full_url.py#L16

I think this happens because nginx hides the fact that the incoming request was an HTTPS request; see https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-SECURE_PROXY_SSL_HEADER (and also https://gitlab.idiap.ch/beat/beat.web/issues/196).

I opened a separate issue #255 for implementing the Django security recommendations for HTTPS; it may well be that that would also resolve #250, but that's a slightly larger task; if we don't need the absolute URLs, this would be a quicker fix.