### PR TITLE
use bootstrap for username tooltips on avatars

### DIFF
--- a/templates/fragments/avatar.html
+++ b/templates/fragments/avatar.html
@@ -2,6 +2,8 @@
 <img
 	src="{% avatar_full_url user size %}"
 	title="{{user.firstname|default:user.username}}"
+	data-toggle="tooltip"
+	data-placement="bottom"
 	width="{{ size }}"
 	height="{{ size }}"
 	class="avatar"


### PR DESCRIPTION
fixes #263 

I put the tooltips on the bottom because if they're at the top the one at the top right is cut off.

The tooltip is a bit redundant in the initiator list on initiative pages, since the name is under the avatar anyway; OTOH, it's a nice effect, as the tooltip text happens to exactly overlay and invert the name (at least in Firefox, Safari and Chrome on a Mac).

Note that you won't see this on non-initiative item pages until #262 is merged, since bootstrap tooltips weren't activated there.