### PR TITLE
some small fixes

### DIFF
--- a/static/js/dib/utils.js
+++ b/static/js/dib/utils.js
@@ -78,7 +78,7 @@ function update_notifications(data) {
 
         case "init_new_arg":
             message = `<a href="/initiative/${item.target_object_id}">
-                <i class="material-icons">comment</i>${item.actor} hat ein neues Argument zu "${item.target}"" veröffentlicht.
+                <i class="material-icons">comment</i>${item.actor} hat ein neues Argument zu "${item.target}" veröffentlicht.
             </a>`
           break;
 

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -142,7 +142,7 @@
     </div>
     <!-- Needed by Bootstrap 4.0 -->
     <script src="{% static 'js/vendor/jquery-3.2.1.min.js' %}"></script>
-    <script src="{% static 'js/dib/utils.js' %}"" type="text/javascript"></script>
+    <script src="{% static 'js/dib/utils.js' %}" type="text/javascript"></script>
     <script src="{% static 'notifications/notify.js' %}" type="text/javascript"></script>
     {% register_notify_callbacks callbacks='update_notifications,fill_notification_badge' %}
     <script type="text/javascript" src="{% static 'django_ajax/js/jquery.ajax.min.js' %}"></script>
@@ -150,6 +150,6 @@
     <script type="text/javascript" src="{% static 'bootstrap-4.0.0-alpha.6-dist/js/tether.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'bootstrap-4.0.0-alpha.6-dist/js/bootstrap.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/vendor/js-cookie.js' %}"></script>
-    <script src="{% static 'js/vendor/hyphenator-loader.js' %}"" type="text/javascript"></script>
+    <script src="{% static 'js/vendor/hyphenator-loader.js' %}" type="text/javascript"></script>
     {% block body-javascript %}{% endblock %}
 </body>

--- a/templates/fragments/participation.html
+++ b/templates/fragments/participation.html
@@ -22,8 +22,8 @@
 <p style="padding-top:30px">{{preference.option.text}}</p>
 <div class="btn-group" role="group" style="display:inline">
 	{% for i in "01234567890" %}
-	<label for="o{{preference.option.index}}{{forloop.counter0}}">
-		<input type="radio" onchange="javascript:enable_submit({{preference.option.index}})" name="option{{preference.option.index}}" id="o{{preference.option.index}}{{forloop.counter0}}" value="{{forloop.counter0}}" {% if preference.value == forloop.counter0 %}checked{% else %}disabled{% endif %}="1" style="margin-right:0.1rem;margin-left:0.8rem">
+	<label>
+		<input type="radio" {% if preference.value == forloop.counter0 %}checked{% else %}disabled{% endif %}="1" style="margin-right:0.1rem;margin-left:0.8rem">
 		{{forloop.counter0}}
 	</label>
 	{% endfor %}

--- a/templates/initproc/item.html
+++ b/templates/initproc/item.html
@@ -113,7 +113,7 @@
                     </p>
                 {% elif initiative.state == 'i' or initiative.state == 'm' %}
                     <p>
-                    Diese Initiative <strong class="badge-prepare">wird gerade geprüft</strong> und {% if initiative.state == 'i' %} wird dann veröffentlicht{% else %} geht dann in <strong  class="badge-prepare">die Abstimmung</strong>{% endif %}.
+                    Diese Initiative <strong class="badge-prepare">wird gerade geprüft</strong> und {% if initiative.state == 'i' %} wird dann veröffentlicht{% else %} geht dann in <strong class="badge-prepare">die Abstimmung</strong>{% endif %}.
                     </p>
                     {% if perms.initproc.add_moderation %}
                         {% if request.guard.can_moderate %}

--- a/templates/initproc/item.html
+++ b/templates/initproc/item.html
@@ -113,7 +113,7 @@
                     </p>
                 {% elif initiative.state == 'i' or initiative.state == 'm' %}
                     <p>
-                    Diese Initiative <strong class="badge-prepare">wird gerade geprüft</strong> und {% if initiative.state == 'i' %} wird dann veröffentlicht {% else %} geht dann in <strong  class="badge-prepare">die Abstimmung</strong>{% endif %}.
+                    Diese Initiative <strong class="badge-prepare">wird gerade geprüft</strong> und {% if initiative.state == 'i' %} wird dann veröffentlicht{% else %} geht dann in <strong  class="badge-prepare">die Abstimmung</strong>{% endif %}.
                     </p>
                     {% if perms.initproc.add_moderation %}
                         {% if request.guard.can_moderate %}
@@ -163,14 +163,15 @@
                     <p>
                         Über diese Initiative <a href="#voting"><strong class="badge-vote">wird gerade abgestimmt</strong></a>.
                     </p>
-                {% endifequal %} {% ifequal initiative.state 'a' %}
-                <p>Diese Initiative {% if user.is_authenticated %}
-                <a href="#cta">{% endif %}<strong class="badge-accepted">wurde angenommen</strong>{% if user.is_authenticated %}</a>{% endif %}.
-                {% endifequal %} {% ifequal initiative.state 'r' %} {% if initiative.went_to_discussion_at %}
-                <p>Diese Initiative <a href="#cta"><strong class="badge-rejected">wurde abgelehnt</strong></a>.</p>
-                {% else %}
-                <p>Diese Initiative <strong class="badge-rejected">wurde abgelehnt</strong>, da sie das Quorum nicht erreicht hat.</p>
-                {% endif %} {% endifequal %}
+                {% endifequal %}
+
+                {% ifequal initiative.state 'a' %}
+                <p>Diese Initiative <a href="#cta"><strong class="badge-accepted">wurde angenommen</strong></a>.</p>
+                {% endifequal %}
+
+                {% ifequal initiative.state 'r' %}
+                <p>Diese Initiative <a href="#cta"><strong class="badge-rejected">wurde abgelehnt</strong></a>{% if not initiative.went_to_discussion_at %}, da sie das Quorum nicht erreicht hat{% endif %}.</p>
+                {% endifequal %}
             </div>
         </div>
     </div>

--- a/templates/initproc/plenumoptions.html
+++ b/templates/initproc/plenumoptions.html
@@ -224,7 +224,6 @@
     <div class="container">
         <div class="row no-gutters">
             {% include "fragments/weighting.html" %}
-
         </div>
     </div>
 </div>

--- a/templates/initproc/plenumvote.html
+++ b/templates/initproc/plenumvote.html
@@ -85,10 +85,13 @@
                 <p>
                     Über diese Plenumsentscheidungsvorlage <a href="#voting"><strong class="badge-vote">wird gerade abgestimmt</strong></a>.
                 </p>
-                {% endifequal %} {% ifequal initiative.state 'a' %}
-                <p>Diese Plenumsentscheidung {% if user.is_authenticated %}
-                    <a href="#cta">{% endif %}<strong class="badge-accepted">wurde angenommen</strong>{% if user.is_authenticated %}</a>{% endif %}.
-                    {% endifequal %} {% ifequal initiative.state 'r' %}
+                {% endifequal %}
+
+                {% ifequal initiative.state 'a' %}
+                <p>Diese Plenumsentscheidung<a href="#cta"><strong class="badge-accepted">wurde angenommen</strong></a>.</p>
+                {% endifequal %}
+
+                {% ifequal initiative.state 'r' %}
                 <p>Diese Plenumsentscheidung <a href="#cta"><strong class="badge-rejected">wurde abgelehnt</strong></a>.</p>
                 {% endifequal %}
             </div>
@@ -260,7 +263,6 @@
     <div class="container">
         <div class="row no-gutters">
             {% include "fragments/voting.html" %}
-
         </div>
     </div>
 </div>

--- a/templates/initproc/policychange.html
+++ b/templates/initproc/policychange.html
@@ -115,10 +115,13 @@
                 <p>
                     Über diese Änderung der Abstimmungsordnung <a href="#voting"><strong class="badge-vote">wird gerade abgestimmt</strong></a>.
                 </p>
-                {% endifequal %} {% ifequal initiative.state 'a' %}
-                <p>Diese Änderung der Abstimmungsordnung {% if user.is_authenticated %}
-                    <a href="#cta">{% endif %}<strong class="badge-accepted">wurde angenommen</strong>{% if user.is_authenticated %}</a>{% endif %}.
-                    {% endifequal %} {% ifequal initiative.state 'r' %}
+                {% endifequal %}
+
+                {% ifequal initiative.state 'a' %}
+                <p>Diese Änderung der Abstimmungsordnung<a href="#cta"><strong class="badge-accepted">wurde angenommen</strong></a>.</p>
+                {% endifequal %}
+
+                {% ifequal initiative.state 'r' %}
                 <p>Diese Änderung der Abstimmungsordnung <a href="#cta"><strong class="badge-rejected">wurde abgelehnt</strong></a>.</p>
                 {% endifequal %}
             </div>

--- a/templates/pinax/notifications/init_discussion/full.txt
+++ b/templates/pinax/notifications/init_discussion/full.txt
@@ -1,3 +1,3 @@
 "{{sender}}" ist jetzt in der Diskussionsphase.
 
-Du findest die Initiative unter {{ base_url }}/initiative/{{sender.id}}-{{sender.slug}}s
+Du findest die Initiative unter {{ base_url }}/initiative/{{sender.id}}-{{sender.slug}}

--- a/templates/pinax/notifications/init_discussion_closed/full.txt
+++ b/templates/pinax/notifications/init_discussion_closed/full.txt
@@ -1,4 +1,4 @@
 Die Diskussionsphase von "{{sender}}" ist beendet und die Initiative kann jetzt finalisiert
 und dann zur Abstimmung eingereicht werden. 
 
-Du findest die Initiative unter {{ base_url }}/initiative/{{sender.id}}-{{sender.slug}}s
+Du findest die Initiative unter {{ base_url }}/initiative/{{sender.id}}-{{sender.slug}}

--- a/voty/initproc/apps.py
+++ b/voty/initproc/apps.py
@@ -38,7 +38,7 @@ def create_notice_types(sender, **kwargs):
 
     NoticeType.create(NOTIFICATIONS.INITIATIVE.WENT_TO_DISCUSSION,
                       'Initiative in Diskussion',
-                      'Die Initiative ist in die Diskussionphase eingetreten')
+                      'Die Initiative ist in die Diskussionsphase eingetreten')
 
     NoticeType.create(NOTIFICATIONS.INITIATIVE.DISCUSSION_CLOSED,
                       'Diskussion zu Initiative beendet',

--- a/voty/initproc/guard.py
+++ b/voty/initproc/guard.py
@@ -10,7 +10,7 @@ from functools import wraps
 from voty.initadmin.models import UserConfig
 from voty.initproc.models import Moderation
 from .globals import STATES, PUBLIC_STATES, TEAM_ONLY_STATES, INITIATORS_COUNT, MINIMUM_MODERATOR_VOTES, \
-    MINIMUM_FEMALE_MODERATOR_VOTES, MINIMUM_DIVERSE_MODERATOR_VOTES, VOTY_TYPES, BOARD_GROUP
+    MINIMUM_FEMALE_MODERATOR_VOTES, MINIMUM_DIVERSE_MODERATOR_VOTES, BOARD_GROUP
 from .models import Initiative, Supporter
 
 

--- a/voty/initproc/migrations/0019_auto_20170808_1628.py
+++ b/voty/initproc/migrations/0019_auto_20170808_1628.py
@@ -10,7 +10,7 @@ import django.db.models.deletion
 from voty.initproc.globals import STATES
 
 def migrate_eligible_voters_count(apps, schema_editor):
-    # Let's set the eligable voters past initiation
+    # Let's set the eligible voters past initiation
     Initiative = apps.get_model('initproc', 'Initiative')
     User = get_user_model()
     for init in Initiative.objects.filter(state__in=[STATES.COMPLETED, STATES.ACCEPTED, STATES.REJECTED]):


### PR DESCRIPTION
- Fix some typos
- Remove some excess quotes, spaces, empty lines and imports
- Remove unnecessary `onchange` attribute on disabled preference display
- Tidy up the template code for acceptance/rejection of items

For approved items, the acceptance text at the top was linked to the voting results further down only if the user was authenticated. That doesn't seem to make much sense, especially as it's not the case for rejected items, so I removed that condition. (Perhaps it was from a time when this area contained only the user's own vote and not the overall result, and there was nothing to link to if the user wasn't authenticated and hence no vote was shown.)