### PR TITLE
Revert "Bump django-cors-headers from 3.13.0 to 3.14.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-autocomplete-light==3.9.4
 django-avatar==7.1.1
 django-bootstrap-form==3.4
 django-braces==1.15.0
-django-cors-headers==3.14.0
+django-cors-headers==3.13.0
 django-fullurl==1.3
 django-mailer==2.2
 django-mathfilters==1.0.0


### PR DESCRIPTION
Reverts DemokratieInBewegung/plenum#482