### PR TITLE
Revert "Bump django-autocomplete-light from 3.5.0 to 3.9.7"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ dj-database-url==2.1.0
 Django==3.2.23
 django-appconf==1.0.6
 #do NOT use higher version; could not get inviting initiators to run with django-autocomplete-light version 3.8.1
-django-autocomplete-light==3.9.7
+django-autocomplete-light==3.5.0
 django-avatar==8.0.0
 django-bootstrap-form==3.4
 django-braces==1.15.0


### PR DESCRIPTION
Reverts DemokratieInBewegung/plenum#531