### PR TITLE
Revert "Bump django-model-utils from 4.5.1 to 5.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-cors-headers==4.4.0
 django-fullurl==1.4
 django-mailer==2.3.2
 django-mathfilters==1.0.0
-django-model-utils==5.0.0
+django-model-utils==4.5.1
 django-notifications-hq==1.8.3
 django-rest-framework==0.1.0
 django-reversion==5.0.12


### PR DESCRIPTION
Reverts DemokratieInBewegung/plenum#695