### PR TITLE
Revert "Bump django-cors-headers from 4.4.0 to 4.6.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-autocomplete-light==3.5.1
 django-avatar==8.0.1
 django-bootstrap-form==3.4
 django-braces==1.15.0
-django-cors-headers==4.6.0
+django-cors-headers==4.4.0
 django-fullurl==1.4
 django-mailer==2.3.2
 django-mathfilters==1.0.0


### PR DESCRIPTION
Reverts DemokratieInBewegung/plenum#704